### PR TITLE
Fixes a compatibility issue in FDDeclaredProperty

### DIFF
--- a/FDFoundationKit/Declared Properties/FDDeclaredProperty.m
+++ b/FDFoundationKit/Declared Properties/FDDeclaredProperty.m
@@ -33,7 +33,8 @@
 		if (firstCharacter == 'T')
 		{
 			// If the attribute contains quotes the property is an object type.
-			if ([attribute containsString: @"\""] == YES)
+			NSRange quoteRange = [attribute rangeOfString: @"\""];
+			if (quoteRange.location != NSNotFound)
 			{
 				NSString *typeName = [attribute substringFromIndex: 2];
 				


### PR DESCRIPTION
FDDeclaredProperty was using `- (BOOL)containsString:aString` to determine if a string contained quotes.
This API was introduced in OS X 10.10 and iOS 8 so its usage was causing crashes on older OS Versions.
